### PR TITLE
feat: create getUsers endpoint

### DIFF
--- a/src/user/controllers/user.controller.ts
+++ b/src/user/controllers/user.controller.ts
@@ -6,7 +6,9 @@ import { CreateUserDto, createUserDto } from '../dto/create-user.dto';
 import { UpdateUserDto, updateUserDto } from '../dto/update-user.dto';
 import { ZodValidationPipe } from "../../shared/pipe/zod-validation.pipe";
 import { hashSync } from 'bcryptjs';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Role } from '../../shared/enums/role.enum';
+import { IUser } from '../entities/models/user.interface';
 
 @ApiTags('user')
 @Controller('user')
@@ -58,6 +60,25 @@ export class UserController {
     }
   }
 
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @Get('users')
+  async getUsers(@Query('role') role: Role) {
+    let users: IUser[];
+    if (!role) {
+      users = await this.userService.getUsers();
+    } else {
+      users = await this.userService.getUsersByRole(role);
+    }
+    if (users) {
+      return users;
+    } else {
+      throw new NotFoundException()
+    }
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
   @Patch()
   async update(
     @Query('email') email: string,
@@ -87,6 +108,8 @@ export class UserController {
     }
   }
 
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
   @Delete()
   async remove(@Query('email') email: string) {
     if(!email) throw new BadRequestException('Especifique o e-mail do usuário.')

--- a/src/user/repositories/pg/user.pg.repository.ts
+++ b/src/user/repositories/pg/user.pg.repository.ts
@@ -5,6 +5,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { CreateUserDto } from "../../../user/dto/create-user.dto";
 import { UpdateUserDto } from "../../../user/dto/update-user.dto";
+import { Role } from "src/shared/enums/role.enum";
 
 export class UserPGRepository implements UserRepository {
   constructor(
@@ -13,6 +14,12 @@ export class UserPGRepository implements UserRepository {
 
   async getUser(email: string): Promise<IUser> {
     return this.userModel.findOne({ where: { email }})
+  }
+  async getUsers(): Promise<IUser[]> {
+    return this.userModel.find()
+  }
+  async getUsersByRole(role: Role): Promise<IUser[]> {
+    return this.userModel.findBy({role})
   }
   async createUser(user: CreateUserDto): Promise<void> {
     await this.userModel.save(user)

--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -1,9 +1,12 @@
+import { Role } from 'src/shared/enums/role.enum';
 import { CreateUserDto } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { IUser } from '../entities/models/user.interface';
 
 export abstract class UserRepository {
   abstract getUser(email: string): Promise<IUser>;
+  abstract getUsers(): Promise<IUser[]>;
+  abstract getUsersByRole(role: Role): Promise<IUser[]>;
   abstract createUser(user: CreateUserDto): Promise<void>;
   abstract updateUser(email: string, user: UpdateUserDto): Promise<void>;
   abstract deleteUser(email: string): Promise<void>;

--- a/src/user/services/user.service.ts
+++ b/src/user/services/user.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { CreateUserDto } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserRepository } from '../repositories/user.repository';
+import { Role } from 'src/shared/enums/role.enum';
 
 @Injectable()
 export class UserService {
@@ -13,6 +14,14 @@ export class UserService {
 
   async findOne(email: string) {
     return this.userRepository.getUser(email);
+  }
+
+  async getUsers() {
+    return this.userRepository.getUsers();
+  }
+
+  async getUsersByRole(role: Role) {
+    return this.userRepository.getUsersByRole(role);
   }
 
   async update(email: string, user: UpdateUserDto) {


### PR DESCRIPTION
Adicionei o endpoint `localhost:3000/user/users` que retornará um array de todos os usuários e para filtrar por `role` é só passar via param: `localhost:3000/user/users?role=teacher`.
Aproveitei para limitar o acesso a esse endpoint e aos de update e delete user para apenas pessoas autenticadas conseguirem fazer a ação.