### PR TITLE
fix: add hash to update user password

### DIFF
--- a/src/user/controllers/user.controller.ts
+++ b/src/user/controllers/user.controller.ts
@@ -101,7 +101,9 @@ export class UserController {
         }  
       }
 
-      this.userService.update(email, updateUserDto);
+      const hashedPassword = updateUserDto.password ? {password: hashSync(updateUserDto.password, 8)} : {};
+
+      this.userService.update(email, {...updateUserDto, ...hashedPassword});
       return 'Usuário atualizado com sucesso!'
     } else {
       throw new NotFoundException()


### PR DESCRIPTION
<img width="619" alt="Screenshot 2024-11-20 at 4 27 56 PM" src="https://github.com/user-attachments/assets/4c3b412d-67c3-4e4c-99c7-99d5d0f29d61">

Adicionei uma validação ao endpoint de atualizar usuário para que quando a senha for alterada, ela seja criptografada antes de ser salva do banco de dados. O que estava ocorrendo é que ela sendo salva como texto puro, além da questão de segurança, ao fazer o login, o back estava tentando descriptografar o texto puro e com isso dava senha incorreta.